### PR TITLE
Stop creating database in bootstrap script

### DIFF
--- a/sql/create_database.sql
+++ b/sql/create_database.sql
@@ -1,11 +1,7 @@
 -- Database bootstrap script for dbaac
--- Creates the database and required extensions/schemas.
+-- Creates the required extensions/schemas inside the currently connected database.
 
 \set ON_ERROR_STOP on
-
-CREATE DATABASE dbaac;
-
-\connect dbaac
 
 -- Required for gen_random_uuid()
 CREATE EXTENSION IF NOT EXISTS pgcrypto;


### PR DESCRIPTION
## Summary
- stop creating and connecting to a dedicated database from the bootstrap script
- document that the script operates on the currently connected database

## Testing
- psql -v ON_ERROR_STOP=1 -f sql/create_database.sql -d postgres *(fails: psql command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc833c0a588321aba9c4ddaeacaeca